### PR TITLE
fix: correctly calculate arity of lambda functions

### DIFF
--- a/src/jsonata/functions.py
+++ b/src/jsonata/functions.py
@@ -1570,9 +1570,12 @@ class Functions:
         from jsonata import jsonata
         if isinstance(func, jsonata.Jsonata.JFunction):
             return func.signature.get_min_number_of_args()
+        elif isinstance(func, jsonata.Jsonata.JLambda):
+            from inspect import signature
+
+            return len(signature(func.function).parameters)
         else:
-            # Lambda
-            return len(func.arguments)
+            raise RuntimeError(f"unexpected function '{type(func)}'")
 
     #
     # Helper function to build the arguments to be supplied to the function arg of the

--- a/src/jsonata/functions.py
+++ b/src/jsonata/functions.py
@@ -1575,7 +1575,7 @@ class Functions:
 
             return len(signature(func.function).parameters)
         else:
-            raise RuntimeError(f"unexpected function '{type(func)}'")
+            return len(func.arguments)
 
     #
     # Helper function to build the arguments to be supplied to the function arg of the

--- a/tests/custom_function_test.py
+++ b/tests/custom_function_test.py
@@ -26,4 +26,4 @@ class TestCustomFunction:
     def test_map(self):
         expression = jsonata.Jsonata("$map([1, 2, 3], $square)")
         expression.register_lambda("square", lambda x: x * x)
-        assert expression.evaluate([1, 2, 3]) == [1, 4, 9]
+        assert expression.evaluate(None) == [1, 4, 9]

--- a/tests/custom_function_test.py
+++ b/tests/custom_function_test.py
@@ -22,3 +22,8 @@ class TestCustomFunction:
         expression = jsonata.Jsonata("$abc(a,b,c)")
         expression.register_lambda("abc", lambda x, y, z: str(x) + str(y) + str(z))
         assert expression.evaluate({"a": "a", "b": "b", "c": "c"}) == "abc"
+
+    def test_map(self):
+        expression = jsonata.Jsonata("$map([1, 2, 3], $square)")
+        expression.register_lambda("square", lambda x: x * x)
+        assert expression.evaluate([1, 2, 3]) == [1, 4, 9]

--- a/tests/custom_function_test.py
+++ b/tests/custom_function_test.py
@@ -23,7 +23,11 @@ class TestCustomFunction:
         expression.register_lambda("abc", lambda x, y, z: str(x) + str(y) + str(z))
         assert expression.evaluate({"a": "a", "b": "b", "c": "c"}) == "abc"
 
-    def test_map(self):
+    def test_map_with_lambda(self):
         expression = jsonata.Jsonata("$map([1, 2, 3], $square)")
         expression.register_lambda("square", lambda x: x * x)
+        assert expression.evaluate(None) == [1, 4, 9]
+
+    def test_map_with_function(self):
+        expression = jsonata.Jsonata("$map([1, 2, 3], function($v) { $v * $v })")
         assert expression.evaluate(None) == [1, 4, 9]


### PR DESCRIPTION
Currently you cant use a lambda function in combination with functions like map as the arity of the lambda function is calculated in a way that does not work.

This fix uses the suggested method to calculate the number of parameters for a callable, see https://stackoverflow.com/a/41188411