### PR TITLE
Fix chain operator to respect array constructor

### DIFF
--- a/src/jsonata/parser.py
+++ b/src/jsonata/parser.py
@@ -1246,7 +1246,6 @@ class Parser:
 
             result.arguments = [lambda4(x) for x in expr.arguments]
             result.procedure = self.process_ast(expr.procedure)
-            result.keep_array = result.procedure.keep_array
         elif type == "lambda":
             result = Parser.Symbol(self)
             result.type = expr.type

--- a/src/jsonata/parser.py
+++ b/src/jsonata/parser.py
@@ -1180,6 +1180,7 @@ class Parser:
                 result.position = expr.position
                 result.lhs = self.process_ast(expr.lhs)
                 result.rhs = self.process_ast(expr.rhs)
+                result.keep_array = result.lhs.keep_array or result.rhs.keep_array
             else:
                 result = Parser.Infix(self, None)
                 result.type = expr.type
@@ -1245,6 +1246,7 @@ class Parser:
 
             result.arguments = [lambda4(x) for x in expr.arguments]
             result.procedure = self.process_ast(expr.procedure)
+            result.keep_array = result.procedure.keep_array
         elif type == "lambda":
             result = Parser.Symbol(self)
             result.type = expr.type

--- a/tests/custom_function_test.py
+++ b/tests/custom_function_test.py
@@ -31,13 +31,3 @@ class TestCustomFunction:
     def test_map_with_function(self):
         expression = jsonata.Jsonata("$map([1, 2, 3], function($v) { $v * $v })")
         assert expression.evaluate(None) == [1, 4, 9]
-
-    def test_singleton_map(self):
-        expression = jsonata.Jsonata("$map([1], $square)[]")
-        expression.register_lambda("square", lambda x: x * x)
-        assert expression.evaluate(None) == [1]
-
-    def test_singleton_map_with_chain(self):
-        expression = jsonata.Jsonata("$ ~> $map($square)[]")
-        expression.register_lambda("square", lambda x: x * x)
-        assert expression.evaluate([1]) == [1]

--- a/tests/custom_function_test.py
+++ b/tests/custom_function_test.py
@@ -31,3 +31,13 @@ class TestCustomFunction:
     def test_map_with_function(self):
         expression = jsonata.Jsonata("$map([1, 2, 3], function($v) { $v * $v })")
         assert expression.evaluate(None) == [1, 4, 9]
+
+    def test_singleton_map(self):
+        expression = jsonata.Jsonata("$map([1], $square)[]")
+        expression.register_lambda("square", lambda x: x * x)
+        assert expression.evaluate(None) == [1]
+
+    def test_singleton_map_with_chain(self):
+        expression = jsonata.Jsonata("$ ~> $map($square)[]")
+        expression.register_lambda("square", lambda x: x * x)
+        assert expression.evaluate([1]) == [1]


### PR DESCRIPTION
This fixes the implementation to be able to force the map function to return an array even if there is a single element.

This seems to be common for all jsonata implementations, that map returns a single element if its result is a singleton list. The commonly shared workaround is to add [] at the end of the function as explained here: https://github.com/jsonata-js/jsonata/issues/462#issuecomment-713869797

This was not working before, the fix propagates the keep_array setting to the parent AST element in some cases to support that. I am not sure if this is generally correct, it fixes the test cases though that I added to illustrate the problem.