### PR TITLE
Backport: fix varargs (i.e. <n+:n>) signature validation

### DIFF
--- a/src/jsonata/signature.py
+++ b/src/jsonata/signature.py
@@ -307,6 +307,7 @@ class Signature:
                             validated_args.append(arg)
                             arg_index += 1
                         else:
+                            arg = args[arg_index] if arg_index < len(args) else None
                             validated_args.append(arg)
                             arg_index += 1
             return validated_args


### PR DESCRIPTION
Using <n+:n> signature, validate will return the first arg n times. 

As Python was ported from the Java impl it should be backported:

Original fix here:
https://github.com/dashjoin/jsonata-java/commit/3849b71066908de22e70fa076ff21e19ee5a11d6

Test case:
https://github.com/dashjoin/jsonata-java/commit/abf12e92c1155ea092b147278b4d8fcb3bcc42ad