### PR TITLE
Add script to allow installation with pipx and simplify CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The CLI provides the same functionality as the [Dashjoin JSONata CLI](https://gi
 
 ```
 % jsonata -h
-usage: jsonata.cli [-h] [-v] [-e <file>] [-i <arg>] [-ic <arg>] [-f {auto,json,string}] [-o <arg>] [-oc <arg>] [-time] [-c] [-b <json-string>]
+usage: jsonata [-h] [-v] [-e <file>] [-i <arg>] [-ic <arg>] [-f {auto,json,string}] [-o <arg>] [-oc <arg>] [-time] [-c] [-b <json-string>]
                    [-bf <file>] [-it]
                    [expr]
 

--- a/README.md
+++ b/README.md
@@ -76,19 +76,19 @@ options:
 ### Examples
 
 ```
-% echo '{"a":"hello", "b":" world"}' | python3 -m jsonata.cli '(a & b)'
+% echo '{"a":"hello", "b":" world"}' | jsonata '(a & b)'
 hello world
 
-% echo '{"a":"hello", "b":" world"}' | python3 -m jsonata.cli -o helloworld.json $
+% echo '{"a":"hello", "b":" world"}' | jsonata -o helloworld.json $
 # helloworld.json written
 
-% ls | python3 -m jsonata.cli $
+% ls | jsonata $
 helloworld.json
 
-% ps -o pid="",%cpu="",%mem="" | python3 -m jsonata.cli '$.$split(/\n/).$trim().[ $split(/\s+/)[$length()>0].$number() ]' -c
+% ps -o pid="",%cpu="",%mem="" | jsonata '$.$split(/\n/).$trim().[ $split(/\s+/)[$length()>0].$number() ]' -c
 [[4105,0,0],[4646,0,0],[4666,0,0],[33696,0,0]...]
 
-% curl -s https://raw.githubusercontent.com/jsonata-js/jsonata/master/test/test-suite/datasets/dataset1.json | python3 -m jsonata.cli '{"Name": FirstName & " " & Surname, "Cities": **.City, "Emails": Email[type="home"].address}'
+% curl -s https://raw.githubusercontent.com/jsonata-js/jsonata/master/test/test-suite/datasets/dataset1.json | jsonata '{"Name": FirstName & " " & Surname, "Cities": **.City, "Emails": Email[type="home"].address}'
 {
   "Name": "Fred Smith",
   "Cities": [
@@ -101,7 +101,7 @@ helloworld.json
   ]
 }
 
-% python3 -m jsonata.cli -i helloworld.json -it
+% jsonata -i helloworld.json -it
 Enter an expression to have it evaluated.
 JSONata> (a & b)
 hello world

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The JSONata documentation can be found [here](https://jsonata.org).
 ## Installation
 
 ```
-pip install jsonata-python
+pipx install jsonata-python
 ```
 
 ## Getting Started
@@ -39,7 +39,7 @@ A very simple start:
 The CLI provides the same functionality as the [Dashjoin JSONata CLI](https://github.com/dashjoin/jsonata-cli).
 
 ```
-% python3 -m jsonata.cli
+% jsonata -h
 usage: jsonata.cli [-h] [-v] [-e <file>] [-i <arg>] [-ic <arg>] [-f {auto,json,string}] [-o <arg>] [-oc <arg>] [-time] [-c] [-b <json-string>]
                    [-bf <file>] [-it]
                    [expr]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[project.scripts]
+jsonata = "jsonata.cli.__main__:main"
 
 [project]
 name = "jsonata-python"

--- a/src/jsonata/cli/__main__.py
+++ b/src/jsonata/cli/__main__.py
@@ -32,7 +32,7 @@ from jsonata import functions, jexception, jsonata, timebox
 def get_options(argv: Optional[list[str]] = None) -> argparse.ArgumentParser:
     """Parses command-line arguments.
     """
-    parser = argparse.ArgumentParser(prog="jsonata.cli", description="Pure Python JSONata CLI")
+    parser = argparse.ArgumentParser(prog="jsonata", description="Pure Python JSONata CLI")
     parser.add_argument(
         "-v", "--version", action='version', version='%(prog)s 0.6.0')
 


### PR DESCRIPTION
This PR allows installation with tools like pipx:

```
# pipx install .
  installed package jsonata-python 0.6.0, installed using Python 3.13.3
  These apps are now globally available
    - jsonata
done! ✨ 🌟 ✨

# jsonata -h
usage: jsonata.cli [-h] [-v] [-e <file>] [-i <arg>] [-ic <arg>] [-f {auto,json,string}] [-o <arg>] [-oc <arg>] [-time] [-c] [-b <json-string>] [-bf <file>] [-it] [expr]

Pure Python JSONata CLI

positional arguments:
  expr

options:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  -e, --expression <file>
                        JSON expression to evaluate.
  -i, --input <arg>     JSON input file (- for stdin)
  -ic, --icharset <arg>
                        Input character set (default=utf-8)
  -f, --format {auto,json,string}
                        Input format (default=auto)
  -o, --output <arg>    JSON output file (default=stdout)
  -oc, --ocharset <arg>
                        Output character set (default=utf-8)
  -time                 Print performance timers to stderr
  -c, --compact         Compact JSON output (don't prettify)
  -b, --bindings <json-string>
                        JSONata variable bindings
  -bf, --bindings-file <file>
                        JSONata variable bindings file
  -it, --interactive    Interactive REPL (requires input file)

```

Without this change:
```
# pipx install jsonata-python

No apps associated with package jsonata-python or its dependencies. If you are attempting to install a library, pipx should not be used. Consider using pip or a similar tool instead.
```