### PR TITLE
Update GitHub action versions to resolve deprecation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
     - name: Install test dependencies


### PR DESCRIPTION
CI runs are currently throwing deprecation warnings [[recent example](https://github.com/rayokota/jsonata-python/actions/runs/23098754746)].

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3, actions/setup-python@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

This PR updates the affected action versions to resolve the deprecation warnings.