### PR TITLE
Preserve JSON null when indexing into an array

### DIFF
--- a/src/jsonata/jsonata.py
+++ b/src/jsonata/jsonata.py
@@ -512,15 +512,21 @@ class Jsonata:
         results = utils.Utils.create_sequence()
         if isinstance(input, utils.Utils.JList) and input.tuple_stream:
             results.tuple_stream = True
-        if not (isinstance(input, list)):
+        if input is None:
+            # undefined input yields undefined output; skip filtering entirely
+            input = utils.Utils.create_sequence()
+        elif not (isinstance(input, list)):
             input = utils.Utils.create_sequence(input)
         if predicate.type == "number":
             index = int(predicate.value)  # round it down - was Math.floor
             if index < 0:
                 # count in from end of array
                 index = len(input) + index
-            item = input[index] if 0 <= index < len(input) else None
-            if item is not None:
+            if 0 <= index < len(input):
+                item = input[index]
+                # Preserve JSON null at this index (vs. out-of-bounds, which is undefined)
+                if item is None:
+                    item = utils.Utils.NULL_VALUE
                 if isinstance(item, list):
                     results = item
                 else:

--- a/tests/null_safety_test.py
+++ b/tests/null_safety_test.py
@@ -31,3 +31,10 @@ class TestNullSafety:
 
         res = jsonata.Jsonata("$spread(null)").evaluate(None)
         assert res is None
+
+    def test_array_index_preserves_null(self):
+        # Indexing into an array element that is JSON null must yield null,
+        # not be filtered out as if it were undefined.
+        data = {"data": [[1, None, 3], [2, None, 4], [3, None, 5]]}
+        res = jsonata.Jsonata("[$map(data, function($row) { $row[1] })]").evaluate(data)
+        assert res == [None, None, None]


### PR DESCRIPTION
`evaluate_filter` was treating an in-bounds array element that happens to be JSON `null` the same as an out-of-bounds access, so a numeric predicate like `$row[1]` would silently drop the element instead of returning `null`.

Fixes https://github.com/rayokota/jsonata-python/issues/35